### PR TITLE
Write each tag to a new line instead of one long line

### DIFF
--- a/src/OpenGraph.php
+++ b/src/OpenGraph.php
@@ -416,6 +416,6 @@ class OpenGraph
             $tags[] = sprintf($metaTagPattern, 'fb:admins', implode(';', $this->_facebookAdminList));
         }
 
-        return implode('', $tags);
+        return implode(PHP_EOL, $tags);
     }
 }


### PR DESCRIPTION
Just a minor thing, this helps with debugging the page's meta tags.

I believe this should be the the default behavior and then let people have control after `toArray()` is called.